### PR TITLE
fix bug with install: i -> pkg

### DIFF
--- a/install.R
+++ b/install.R
@@ -39,7 +39,7 @@ install_missing_packages = function(pkg, version = NULL, verbose = TRUE){
     }
   }
   if(missingPackage){
-    biocLite(i, suppressUpdates = TRUE)
+    biocLite(pkg, suppressUpdates = TRUE)
   }
 }
 ################################################################################


### PR DESCRIPTION
There was a bug in the install.R file which would yield the following:

```
The following package is missing.
genefilter
Installation will be attempted...
 Hide Traceback
 
 Rerun with Debug
 Error in biocLite(i, suppressUpdates = TRUE) : object 'i' not found 
8.
"BiocUpgrade" %in% pkgs 
7.
biocLite(i, suppressUpdates = TRUE) at install_shiny-phyloseq.R#42
```